### PR TITLE
Fix duplicate entry in aqua package list

### DIFF
--- a/.config/aqua/aqua.yaml
+++ b/.config/aqua/aqua.yaml
@@ -41,7 +41,6 @@ packages:
 - name: stern/stern@v1.32.0
 - name: kubernetes-sigs/kind@v0.29.0
 - name: denoland/deno@v2.3.5
-- name: denoland/deno@v2.3.5
 - name: cue-lang/cue@v0.13.0
 - name: ogham/exa@v0.10.1
 - name: open-policy-agent/conftest@v0.61.2


### PR DESCRIPTION
## Summary
- remove duplicated `denoland/deno` package entry from `.config/aqua/aqua.yaml`

## Testing
- `make list`

------
https://chatgpt.com/codex/tasks/task_e_68491d0dc1e483208c242e8c1a78124a