### PR TITLE
refactor: move aliases into dedicated fish script

### DIFF
--- a/.config/fish/conf.d/25-aliases.fish
+++ b/.config/fish/conf.d/25-aliases.fish
@@ -1,4 +1,9 @@
 # Common navigation and listing aliases
+if has eza
+    alias ls='eza'
+else if has exa
+    alias ls='exa'
+end
 alias ..='cd ..'
 alias l='ls -l'
 alias lla='ls -lAF'
@@ -18,9 +23,28 @@ alias grep='grep --color=auto'
 alias fgrep='fgrep --color=auto'
 alias egrep='egrep --color=auto'
 
+# Git and development tools
+if has git
+    alias gst='git status'
+end
+if has kubectl
+    alias k='kubectl'
+end
+if has lazygit
+    alias lg='lazygit'
+end
+if has lazydocker
+    alias ld='lazydocker'
+end
+
+# 1Password integration
+if has op
+    alias aqua='env GITHUB_TOKEN=(op read -f "op://Private/GitHub Personal Access Token/token") aqua'
+end
+
 # macOS specific
 if test (uname -s) = Darwin
-    if type -q brew
+    if has brew
         set -l brew_prefix (brew --prefix)
         alias ctags="$brew_prefix/bin/ctags"
     end

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -138,36 +138,6 @@ set -gx SVN_EDITOR $EDITOR
 set -gx GIT_EDITOR $EDITOR
 
 # ============================================================================
-# Aliases
-# ============================================================================
-
-# Git aliases
-if type -q git
-    alias gst='git status'
-end
-
-# 1Password integration
-if type -q op
-    alias aqua='env GITHUB_TOKEN=(op read -f "op://Private/GitHub Personal Access Token/token") aqua'
-end
-
-# Development tool aliases
-if type -q kubectl
-    alias k='kubectl'
-end
-if type -q eza
-    alias ls='eza'
-else if type -q exa
-    alias ls='exa'
-end
-if type -q lazygit
-    alias lg='lazygit'
-end
-if type -q lazydocker
-    alias ld='lazydocker'
-end
-
-# ============================================================================
 # Vi Mode and Key Bindings
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- streamline `config.fish` by removing inline alias definitions
- consolidate shell aliases inside `conf.d/25-aliases.fish`
- add dynamic `ls` alias using `eza` or `exa`
- replace `type -q` checks with `has` helper for cleaner command detection

## Testing
- `pre-commit run --files .config/fish/conf.d/25-aliases.fish .config/fish/config.fish` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4812a63548320bcdd5a3305f52fdb